### PR TITLE
Switch to libressl

### DIFF
--- a/0.15/Dockerfile
+++ b/0.15/Dockerfile
@@ -18,10 +18,10 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
     file \
     gnupg \
     libevent-dev \
+    libressl \
+    libressl-dev \
     libtool \
     linux-headers \
-    openssl \
-    openssl-dev \
     protobuf-dev \
     zeromq-dev \
   && mkdir -p /tmp/build \
@@ -58,8 +58,8 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
   && apk --no-cache add boost \
     boost-program_options \
     libevent \
+    libressl \
     libzmq \
-    openssl \
     su-exec
 
 VOLUME ["/home/bitcoin/.bitcoin"]


### PR DESCRIPTION
Bitcoin ABC 0.15 is fully compatible with the more secure LibreSSL lib.