### PR TITLE
Fix publishing wrong versions for new tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
               TAGS+=("$REPO:$TAG")
             fi
             TAG_MAJOR_MINOR=$(echo $TAG | cut -c -4)
-            if [ $(version ${TAG_MAJOR_MINOR}) -gt $(version ${BITCOIN_ABC_VERSION}) ]; then
+            if [ $(version ${TAG_MAJOR_MINOR}) -ne $(version ${BITCOIN_ABC_VERSION}) ]; then
               echo "Skipping build of base image $BITCOIN_ABC_VERSION/ as ${TAG} is targeted at ${TAG_MAJOR_MINOR}/"
               exit 0
             fi


### PR DESCRIPTION
## Problem

New tags which evaluate to be less than the targeted folder version will not trigger the `exit 0`.

### Example
When TAG_MAJOR_MINOR is 0.15.x and BITCOIN_ABC_VERSION is greater than 0.15
```
# Will not trigger exit 0
if [ $(version ${TAG_MAJOR_MINOR}) -gt $(version ${BITCOIN_ABC_VERSION}) ]; then
  echo "Skipping build of base image $BITCOIN_ABC_VERSION/ as ${TAG} is targeted at ${TAG_MAJOR_MINOR}/"
  exit 0
fi
```

### Behaviour

All jobs for folder versions which are greater than the tag version will not skip and will instead race to update the new tag in dockerhub.